### PR TITLE
fix width and height for lime 4

### DIFF
--- a/com/babylonhx/Engine.hx
+++ b/com/babylonhx/Engine.hx
@@ -623,7 +623,7 @@ typedef BufferPointer = {
 			return this._currentRenderTarget._width;
 		}
 		
-		#if (js || purejs)
+		#if ((js || purejs) && !lime)
 		return this._renderingCanvas.width;
 		#else
 		return this.width;
@@ -635,7 +635,7 @@ typedef BufferPointer = {
 			return this._currentRenderTarget._height;
 		}
 		
-		#if (js || purejs)
+		#if ((js || purejs) && !lime)
 		return this._renderingCanvas.height;
 		#else
 		return this.height;

--- a/com/babylonhx/Engine.hx
+++ b/com/babylonhx/Engine.hx
@@ -251,7 +251,7 @@ typedef BufferPointer = {
 			options.preserveDrawingBuffer = false;
 		}
 		
-		#if lime
+		#if (lime)
 		Gl = GL.context;
 		#elseif (purejs || js)
 			#if lime
@@ -315,9 +315,9 @@ typedef BufferPointer = {
 		this._glVendor = Gl.getParameter(GL.VENDOR);
 		this._glRenderer = Gl.getParameter(GL.RENDERER);
 		this._glExtensions = Gl.getSupportedExtensions();
-		//for (ext in this._glExtensions) {
-			//trace(ext);
-		//}
+		/*for (ext in this._glExtensions) {
+			trace(ext);
+		}*/
 		//trace(this._glExtensions);
 		
 		#if (!snow || (js && snow))
@@ -1336,7 +1336,11 @@ typedef BufferPointer = {
 		buffer.references--;
 		
 		if (buffer.references == 0) {
+			#if lime
+			buffer.buffer.deleteBuffer();
+			#else
 			Gl.deleteBuffer(buffer.buffer);
+			#end
 			return true;
 		}
 		
@@ -1355,7 +1359,11 @@ typedef BufferPointer = {
 	}
 
 	public function deleteInstancesBuffer(buffer:WebGLBuffer) {
+		#if lime
+		buffer.buffer.deleteBuffer();
+		#else
 		Gl.deleteBuffer(buffer.buffer);
+		#end
 		buffer = null;
 	}
 	
@@ -2972,7 +2980,11 @@ typedef BufferPointer = {
 		var cleanup = function() {
 			Gl.deleteProgram(program);
 			Gl.disableVertexAttribArray(positionLocation);
+			#if lime
+			positionBuffer.deleteBuffer();
+			#else
 			Gl.deleteBuffer(positionBuffer);
+			#end
 			Gl.deleteFramebuffer(fb);
 			Gl.deleteTexture(whiteTex);
 			Gl.deleteTexture(tex);
@@ -3001,7 +3013,7 @@ typedef BufferPointer = {
 		Gl.drawArrays(GL.TRIANGLES, 0, 6);
 		
 		var pixel = new UInt8Array(4);
-		Gl.readPixels(0, 0, 1, 1, GL.RGBA, GL.UNSIGNED_BYTE, pixel);
+		Gl.readPixels(0, 0, 1, 1, GL.RGBA, GL.UNSIGNED_BYTE, pixel);		
 		if (pixel[0] != 0 ||
 			pixel[1] < 248 ||
 			pixel[2] < 248 ||

--- a/com/babylonhx/Engine.hx
+++ b/com/babylonhx/Engine.hx
@@ -1336,11 +1336,7 @@ typedef BufferPointer = {
 		buffer.references--;
 		
 		if (buffer.references == 0) {
-			#if lime
-			buffer.buffer.deleteBuffer();
-			#else
 			Gl.deleteBuffer(buffer.buffer);
-			#end
 			return true;
 		}
 		
@@ -1359,11 +1355,7 @@ typedef BufferPointer = {
 	}
 
 	public function deleteInstancesBuffer(buffer:WebGLBuffer) {
-		#if lime
-		buffer.buffer.deleteBuffer();
-		#else
 		Gl.deleteBuffer(buffer.buffer);
-		#end
 		buffer = null;
 	}
 	
@@ -2980,11 +2972,7 @@ typedef BufferPointer = {
 		var cleanup = function() {
 			Gl.deleteProgram(program);
 			Gl.disableVertexAttribArray(positionLocation);
-			#if lime
-			positionBuffer.deleteBuffer();
-			#else
 			Gl.deleteBuffer(positionBuffer);
-			#end
 			Gl.deleteFramebuffer(fb);
 			Gl.deleteTexture(whiteTex);
 			Gl.deleteTexture(tex);


### PR DESCRIPTION
basic scene sample works now ( lime 4 / html5 target :)

for cpp i did not found ... there is this warning msg while dir render-to-texture test here:
Engine.hx:3009: GL Support: Was not able to actually render to 1 texture
Engine.hx:3009: GL Support: Was not able to actually render to 2 texture
( but no plan why it not renders the geometry)  


to let basic scene work with lime 3.7.4 in master-branch: type "webgl2" instead of "webgl" while setting "Gl" in Engine.hx (cpp/html5)
